### PR TITLE
Add option export from history

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![npm](https://img.shields.io/npm/v/jupyterlab_conda.svg?style=flat-square)](https://www.npmjs.com/package/jupyterlab_conda)
 [![Build Status](https://travis-ci.com/fcollonval/jupyter_conda.svg?branch=master)](https://travis-ci.com/fcollonval/jupyter_conda)
 [![Coverage Status](https://coveralls.io/repos/github/fcollonval/jupyter_conda/badge.svg?branch=master)](https://coveralls.io/github/fcollonval/jupyter_conda?branch=master)
+[![Swagger Validator](https://img.shields.io/swagger/valid/3.0?specUrl=https%3A%2F%2Fraw.githubusercontent.com%2Ffcollonval%2Fjupyter_conda%2Fmaster%2Fjupyter_conda%2Frest_api.yml)](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/fcollonval/jupyter_conda/master/jupyter_conda/rest_api.yml)
 
 Provides Conda environment and package access extension from within Jupyter Notebook and JupyterLab.
 

--- a/jupyter_conda/envmanager.py
+++ b/jupyter_conda/envmanager.py
@@ -256,7 +256,6 @@ class EnvManager(LoggingConfigurable):
                 )
             else:
                 command.append("--from-history")
-
         ans = await self._execute(*command)
         rcode, output = ans
         if rcode > 0:

--- a/jupyter_conda/envmanager.py
+++ b/jupyter_conda/envmanager.py
@@ -302,7 +302,10 @@ class EnvManager(LoggingConfigurable):
         info = self._clean_conda_json(output)
         if rcode == 0:
             EnvManager._conda_version = tuple(
-                info.get("conda_version", EnvManager._conda_version).split(".")
+                map(
+                    lambda part: int(part),
+                    info.get("conda_version", EnvManager._conda_version).split("."),
+                )
             )
         return info
 

--- a/jupyter_conda/handlers.py
+++ b/jupyter_conda/handlers.py
@@ -233,16 +233,18 @@ class EnvironmentHandler(EnvBaseHandler):
         Query arguments:
             status: "installed" (default) or "has_update"
             download: 0 (default) or 1
+            history: 0 (default) or 1
         """
         status = self.get_query_argument("status", "installed")
         download = self.get_query_argument("download", 0)
+        history = self.get_query_argument("history", 0)
 
         if download:
             # export requirements file
             self.set_header(
                 "Content-Disposition", 'attachment; filename="%s"' % (env + ".yml")
             )
-            answer = await self.env_manager.export_env(env)
+            answer = await self.env_manager.export_env(env, bool(history))
             if "error" in answer:
                 self.set_status(500)
                 self.finish(tornado.escape.json_encode(answer))

--- a/jupyter_conda/handlers.py
+++ b/jupyter_conda/handlers.py
@@ -487,7 +487,7 @@ default_handlers = [
     # PATCH / POST / DELETE
     (r"/environments/%s/packages" % _env_regex, PackagesEnvironmentHandler),
     (r"/packages", PackagesHandler),  # GET
-    (r"/tasks/%s" % r"(?P<index>\d+)", TaskHandler),  # GET
+    (r"/tasks/%s" % r"(?P<index>\d+)", TaskHandler),  # GET / DELETE
 ]
 
 

--- a/jupyter_conda/rest_api.yml
+++ b/jupyter_conda/rest_api.yml
@@ -1,0 +1,258 @@
+swagger: "2.0"
+info:
+  description: "This is the REST API introduce by the Jupyter server extension `jupyter_conda`; see [GitHub repository](https://github.com/fcollonval/jupyter_conda) for more information."
+  version: "3.3.0"
+  title: "jupyter_conda API"
+  license:
+    name: "BSD-3-Clause"
+    url: "https://opensource.org/licenses/BSD-3-Clause"
+basePath: "/conda"
+tags:
+  - name: "channel"
+    description: "Conda channel"
+  - name: "environment"
+    description: "Conda environment actions"
+  - name: "package"
+    description: "Conda package actions"
+  - name: "task"
+    description: "Long running task actions"
+schemes:
+  - "https"
+paths:
+  /channels:
+    get:
+      tags:
+        - "channel"
+      summary: "List conda channels"
+      responses:
+        "200":
+          description: "Conda channels"
+        "500":
+          description: "Fail to list conda channels"
+  /environments:
+    get:
+      tags:
+        - "environment"
+      summary: "List conda environments"
+      produces:
+        - "application/json"
+      parameters:
+        - name: "whitelist"
+          in: "query"
+          description: "Whether to respect KernelSpecManager.whitelist"
+          type: "integer"
+          default: 0
+      responses:
+        "200":
+          description: "Conda environments"
+        "500":
+          description: "Fail to list environments"
+    post:
+      tags:
+        - "environment"
+      summary: "Add a new conda environment"
+      consumes:
+        - "application/json"
+      parameters:
+        - in: "body"
+          name: "body"
+          description: "Environment option"
+          required: true
+          schema:
+            $ref: "#/definitions/EnvironmentPost"
+      responses:
+        "202":
+          description: "Redirect on tasks"
+  /environments/{environmentName}:
+    get:
+      tags:
+        - "environment"
+      summary: "List the environment content"
+      produces:
+        - "application/json"
+        - "attachment"
+      parameters:
+        - name: "environmentName"
+          in: "path"
+          description: "Environment name to return"
+          required: true
+          type: "string"
+          pattern: /([^/&+$?@<>%*-][^/&+$?@<>%*]*)/
+        - name: "status"
+          in: "query"
+          description: "installed or has_update"
+          type: "string"
+          default: "installed"
+          enum: ["installed", "has_update"]
+        - name: "download"
+          in: "query"
+          description: "Whether to download the packages list"
+          type: "integer"
+          default: 0
+        - name: "history"
+          in: "query"
+          description: "Whether to export only from history"
+          type: "integer"
+          default: 0
+      responses:
+        "200":
+          description: "Package list"
+          schema:
+            type: "object"
+            properties:
+              packages:
+                type: "array"
+                items:
+                  $ref: "#/definitions/Package"
+
+        "202":
+          description: "Redirect long running task"
+        "500":
+          description: "Error listing the packages"
+    patch:
+      tags:
+        - "environment"
+      summary: "Updates the packages environment"
+      consumes:
+        - "application/json"
+      parameters:
+        - name: "environmentName"
+          in: "path"
+          description: "Environment name to update"
+          required: true
+          type: "string"
+          pattern: /([^/&+$?@<>%*-][^/&+$?@<>%*]*)/
+      responses:
+        "202":
+          description: "Long running task"
+    delete:
+      tags:
+        - "environment"
+      summary: "Deletes an environment"
+      description: ""
+      parameters:
+        - name: "environmentName"
+          in: "path"
+          description: "Environment name to remove"
+          required: true
+          type: "string"
+          pattern: /([^/&+$?@<>%*-][^/&+$?@<>%*]*)/
+      responses:
+        "202":
+          description: "Redirect long running task"
+  /environments/{environmentName}/packages:
+    patch:
+      tags:
+        - "package"
+      summary: "Update environment packages"
+      consumes:
+        - "application/json"
+      parameters:
+        - name: "environmentName"
+          in: "path"
+          description: "Environment name to modify"
+          required: true
+          type: "string"
+          pattern: /([^/&+$?@<>%*-][^/&+$?@<>%*]*)/
+      responses:
+        "202":
+          description: "Redirect long running task"
+    post:
+      tags:
+        - "package"
+      summary: "Install environment packages"
+      consumes:
+        - "application/json"
+      parameters:
+        - name: "environmentName"
+          in: "path"
+          description: "Environment name to modify"
+          required: true
+          type: "string"
+          pattern: /([^/&+$?@<>%*-][^/&+$?@<>%*]*)/
+        - name: "develop"
+          in: "query"
+          description: "Whether to install the package in development mode"
+          type: "integer"
+          default: 0
+      responses:
+        "202":
+          description: "Redirect long running task"
+    delete:
+      tags:
+        - "package"
+      consumes:
+        - "application/json"
+      parameters:
+        - name: "environmentName"
+          in: "path"
+          description: "Environment name to modify"
+          required: true
+          type: "string"
+          pattern: /([^/&+$?@<>%*-][^/&+$?@<>%*]*)/
+      responses:
+        "202":
+          description: "Redirect long running task"
+  /packages:
+    get:
+      tags:
+        - "package"
+      summary: "Search for packages"
+      produces:
+        - "application/json"
+      parameters:
+        - name: "query"
+          in: "query"
+          description: "Query string to pass to conda search"
+          type: "string"
+          default: ""
+      responses:
+        "200":
+          description: "Query result"
+        "202":
+          description: "Redirect long running task"
+  /tasks/{taskId}:
+    get:
+      tags:
+        - "task"
+      summary: "Get long running task result"
+      produces:
+        - "application/json"
+      parameters:
+        - name: "taskId"
+          in: "path"
+          description: "Task ID"
+          required: true
+          type: "integer"
+      responses:
+        "200":
+          description: "Successful execution of the task - returns its result"
+        "202":
+          description: "Task still running"
+        "404":
+          description: "Task not found"
+        "500":
+          description: "An error occurred when executing the task"
+    delete:
+      tags:
+        - "task"
+      summary: "Stop the long running task"
+      parameters:
+        - name: "taskId"
+          in: "path"
+          description: "ID of the order that needs to be deleted"
+          required: true
+          type: "integer"
+      responses:
+        "204":
+          description: "Task cancelled"
+        "404":
+          description: "Task not found"
+definitions:
+  EnvironmentPost:
+    type: "object"
+  Package:
+    type: "object"
+externalDocs:
+  description: "Find out more about jupyter_conda"
+  url: "https://github.com/fcollonval/jupyter_conda"

--- a/jupyter_conda/tests/test_api.py
+++ b/jupyter_conda/tests/test_api.py
@@ -575,11 +575,12 @@ class TestEnvironmentHandler(JupyterCondaAPITest):
 
         content = " ".join(r.text.splitlines())
         self.assertRegex(
-            content, r"^name:\s" + n + r"\s+channels:\s+- python\s+prefix:"
+            content, r"^name:\s" + n + r"\s+channels:\s+- defaults\s+dependencies:\s+- python\s+prefix:"
         )
 
     def test_env_export_not_supporting_history(self):
-        EnvManager._conda_version = (3, 6, 0)
+        manager = TestEnvironmentHandler.notebook.web_app.settings["env_manager"]
+        manager._conda_version = (4, 6, 0)
 
         try:
             n = generate_name()
@@ -596,7 +597,7 @@ class TestEnvironmentHandler(JupyterCondaAPITest):
             self.assertRegex(content, r"- python=\d\.\d+\.\d+=\w+")
             self.assertRegex(content, r"prefix:")
         finally:
-            EnvManager._conda_version = None
+            manager._conda_version = None
 
 
 class TestCondaVersion(JupyterCondaAPITest):

--- a/jupyter_conda/tests/test_api.py
+++ b/jupyter_conda/tests/test_api.py
@@ -5,6 +5,7 @@ import os
 import sys
 import unittest
 import unittest.mock as mock
+
 try:
     from unittest.mock import AsyncMock
 except ImportError:
@@ -75,7 +76,9 @@ class TestChannelsHandler(JupyterCondaAPITest):
             error_msg = "Fail to get channels"
             r = {"error": True, "message": error_msg}
             rvalue = (1, json.dumps(r))
-            f.return_value = tornado.gen.maybe_future(rvalue) if AsyncMock is None else rvalue
+            f.return_value = (
+                tornado.gen.maybe_future(rvalue) if AsyncMock is None else rvalue
+            )
             with assert_http_error(500, msg=error_msg):
                 self.conda_api.get(["channels"])
 
@@ -144,7 +147,9 @@ class TestChannelsHandler(JupyterCondaAPITest):
                 },
             }
             rvalue = (0, json.dumps(data))
-            f.return_value = tornado.gen.maybe_future(rvalue) if AsyncMock is None else rvalue
+            f.return_value = (
+                tornado.gen.maybe_future(rvalue) if AsyncMock is None else rvalue
+            )
 
             response = self.conda_api.get(["channels"])
             self.assertEqual(response.status_code, 200)
@@ -183,7 +188,9 @@ class TestEnvironmentsHandler(JupyterCondaAPITest):
             msg = "Fail to get environments"
             err = {"error": True, "message": msg}
             rvalue = (1, json.dumps(err))
-            f.return_value = tornado.gen.maybe_future(rvalue) if AsyncMock is None else rvalue
+            f.return_value = (
+                tornado.gen.maybe_future(rvalue) if AsyncMock is None else rvalue
+            )
             with assert_http_error(500, msg=msg):
                 self.conda_api.get(["environments"])
 
@@ -561,32 +568,44 @@ class TestEnvironmentHandler(JupyterCondaAPITest):
     def test_env_export_history(self):
         n = generate_name()
         self.wait_for_task(self.mk_env, n)
-        r = self.conda_api.get(["environments", n], params={"download": 1, "history": 1})
+        r = self.conda_api.get(
+            ["environments", n], params={"download": 1, "history": 1}
+        )
         self.assertEqual(r.status_code, 200)
 
         content = " ".join(r.text.splitlines())
-        self.assertRegex(content, r"^name:\s" + n + r"\s+channels:\s+- python\s+prefix:")
+        self.assertRegex(
+            content, r"^name:\s" + n + r"\s+channels:\s+- python\s+prefix:"
+        )
 
-    @mock.patch("jupyter_conda.envmanager.EnvManager._conda_version", (3, 6, 0))
     def test_env_export_not_supporting_history(self):
-        n = generate_name()
-        self.wait_for_task(self.mk_env, n)
-        r = self.conda_api.get(["environments", n], params={"download": 1, "history": 1})
-        self.assertEqual(r.status_code, 200)
+        EnvManager._conda_version = (3, 6, 0)
 
-        content = r.text
-        self.assertRegex(content, r"name: " + n)
-        self.assertRegex(content, r"channels:")
-        self.assertRegex(content, r"dependencies:")
-        self.assertRegex(content, r"- python=\d\.\d+\.\d+=\w+")
-        self.assertRegex(content, r"prefix:")
+        try:
+            n = generate_name()
+            self.wait_for_task(self.mk_env, n)
+            r = self.conda_api.get(
+                ["environments", n], params={"download": 1, "history": 1}
+            )
+            self.assertEqual(r.status_code, 200)
+
+            content = r.text
+            self.assertRegex(content, r"name: " + n)
+            self.assertRegex(content, r"channels:")
+            self.assertRegex(content, r"dependencies:")
+            self.assertRegex(content, r"- python=\d\.\d+\.\d+=\w+")
+            self.assertRegex(content, r"prefix:")
+        finally:
+            EnvManager._conda_version = None
 
 
 class TestCondaVersion(JupyterCondaAPITest):
-
     def test_version(self):
+        EnvManager._conda_version = None
         self.assertIsNone(EnvManager._conda_version)
-        self.conda_api.get(["environments", ])
+        self.conda_api.get(
+            ["environments",]
+        )
         self.assertIsNotNone(EnvManager._conda_version)
 
 
@@ -943,7 +962,11 @@ class TestPackagesHandler(JupyterCondaAPITest):
                     (0, json.dumps(channels)),
                 ]
                 # Use side_effect to have a different return value for each call
-                f.side_effect = map(tornado.gen.maybe_future, rvalue) if AsyncMock is None else rvalue
+                f.side_effect = (
+                    map(tornado.gen.maybe_future, rvalue)
+                    if AsyncMock is None
+                    else rvalue
+                )
 
                 r = self.wait_for_task(self.conda_api.get, ["packages"])
                 self.assertEqual(r.status_code, 200)
@@ -1157,7 +1180,11 @@ class TestPackagesHandler(JupyterCondaAPITest):
                         (0, json.dumps(channels)),
                     ]
                     # Use side_effect to have a different return value for each call
-                    f.side_effect = map(tornado.gen.maybe_future, rvalue) if AsyncMock is None else rvalue
+                    f.side_effect = (
+                        map(tornado.gen.maybe_future, rvalue)
+                        if AsyncMock is None
+                        else rvalue
+                    )
 
                     r = self.wait_for_task(self.conda_api.get, ["packages"])
                     self.assertEqual(r.status_code, 200)
@@ -1360,12 +1387,16 @@ class TestPackagesHandler(JupyterCondaAPITest):
                         },
                     }
 
-                    rvalue =  [
+                    rvalue = [
                         (0, json.dumps(dummy)),
                         (0, json.dumps(channels)),
                     ]
                     # Use side_effect to have a different return value for each call
-                    f.side_effect = map(tornado.gen.maybe_future, rvalue) if AsyncMock is None else rvalue
+                    f.side_effect = (
+                        map(tornado.gen.maybe_future, rvalue)
+                        if AsyncMock is None
+                        else rvalue
+                    )
 
                     r = self.wait_for_task(self.conda_api.get, ["packages"])
                     self.assertEqual(r.status_code, 200)
@@ -1580,7 +1611,11 @@ class TestPackagesHandler(JupyterCondaAPITest):
                     (0, json.dumps(channels)),
                 ]
                 # Use side_effect to have a different return value for each call
-                f.side_effect = map(tornado.gen.maybe_future, rvalue) if AsyncMock is None else rvalue
+                f.side_effect = (
+                    map(tornado.gen.maybe_future, rvalue)
+                    if AsyncMock is None
+                    else rvalue
+                )
 
                 # First retrival no cache available
                 r = self.wait_for_task(self.conda_api.get, ["packages"])

--- a/jupyter_conda/tests/test_api.py
+++ b/jupyter_conda/tests/test_api.py
@@ -579,12 +579,10 @@ class TestEnvironmentHandler(JupyterCondaAPITest):
         )
 
     def test_env_export_not_supporting_history(self):
-        manager = TestEnvironmentHandler.notebook.web_app.settings["env_manager"]
-        manager._conda_version = (4, 6, 0)
-
         try:
             n = generate_name()
             self.wait_for_task(self.mk_env, n)
+            EnvManager._conda_version = (4, 6, 0)
             r = self.conda_api.get(
                 ["environments", n], params={"download": 1, "history": 1}
             )
@@ -597,7 +595,7 @@ class TestEnvironmentHandler(JupyterCondaAPITest):
             self.assertRegex(content, r"- python=\d\.\d+\.\d+=\w+")
             self.assertRegex(content, r"prefix:")
         finally:
-            manager._conda_version = None
+            EnvManager._conda_version = None
 
 
 class TestCondaVersion(JupyterCondaAPITest):

--- a/labextension/schema/plugin.json
+++ b/labextension/schema/plugin.json
@@ -4,10 +4,21 @@
   "title": "Conda",
   "description": "Environments and packages manager settings.",
   "properties": {
-    "whitelist": {
+    "companions": {
+      "type": "object",
+      "title": "Kernel companions",
+      "description": "{'package name': 'semver specification'} - pre and post releases not supported",
+      "default": {},
+      "properties": {
+        "^\\w[\\w\\-]*$": {
+          "type": "string"
+        }
+      }
+    },
+    "fromHistory": {
       "type": "boolean",
-      "title": "Only kernel whitelist",
-      "description": "Show only environment corresponding to whitelisted kernels",
+      "title": "Whether to export environment packages from history or not",
+      "description": "Use --from-history or not for `conda env export`",
       "default": false
     },
     "types": {
@@ -30,16 +41,11 @@
         }
       }
     },
-    "companions": {
-      "type": "object",
-      "title": "Kernel companions",
-      "description": "{'package name': 'semver specification'} - pre and post releases not supported",
-      "default": {},
-      "properties": {
-        "^\\w[\\w\\-]*$": {
-          "type": "string"
-        }
-      }
+    "whitelist": {
+      "type": "boolean",
+      "title": "Only kernel whitelist",
+      "description": "Show only environment corresponding to whitelisted kernels",
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/labextension/src/__tests__/services.spec.ts
+++ b/labextension/src/__tests__/services.spec.ts
@@ -249,7 +249,7 @@ describe("jupyterlab_conda/services", () => {
     // TODO describe("dispose()", () => {});
 
     describe("export()", () => {
-      it("should request to export", async () => {
+      it("should request to export in full format", async () => {
         const name = "dummy";
         (ServerConnection.makeRequest as jest.Mock).mockResolvedValue(
           new Response("", { status: 200 })
@@ -258,7 +258,33 @@ describe("jupyterlab_conda/services", () => {
         const envManager = new CondaEnvironments();
         await envManager.export(name);
 
-        const queryArgs = URLExt.objectToQueryString({ download: 1 });
+        const queryArgs = URLExt.objectToQueryString({
+          download: 1,
+          history: 0
+        });
+        expect(ServerConnection.makeRequest).toBeCalledWith(
+          URLExt.join(settings.baseUrl, "conda", "environments", name) +
+            queryArgs,
+          {
+            method: "GET"
+          },
+          settings
+        );
+      });
+
+      it("should request to export in history format", async () => {
+        const name = "dummy";
+        (ServerConnection.makeRequest as jest.Mock).mockResolvedValue(
+          new Response("", { status: 200 })
+        );
+
+        const envManager = new CondaEnvironments();
+        await envManager.export(name, true);
+
+        const queryArgs = URLExt.objectToQueryString({
+          download: 1,
+          history: 1
+        });
         expect(ServerConnection.makeRequest).toBeCalledWith(
           URLExt.join(settings.baseUrl, "conda", "environments", name) +
             queryArgs,
@@ -364,6 +390,7 @@ describe("jupyterlab_conda/services", () => {
             get: jest.fn().mockImplementation((key: string) => {
               // @ts-ignore
               return {
+                fromHistory: { composite: false },
                 types: { composite: {} },
                 whitelist: { composite: true }
               }[key];

--- a/labextension/src/tokens.ts
+++ b/labextension/src/tokens.ts
@@ -54,7 +54,7 @@ export interface IEnvironmentManager extends IDisposable {
    * @param name Name of the environment to be exported
    * @param fromHistory Whether to export only from the history
    */
-  export(name: string, fromHistory: boolean): Promise<Response>;
+  export(name: string, fromHistory?: boolean): Promise<Response>;
   /**
    * Create an environment from a packages list file
    *

--- a/labextension/src/tokens.ts
+++ b/labextension/src/tokens.ts
@@ -51,9 +51,10 @@ export interface IEnvironmentManager extends IDisposable {
   /**
    * Export the packages list of an environment
    *
-   * @param name name of the environment to be exported
+   * @param name Name of the environment to be exported
+   * @param fromHistory Whether to export only from the history
    */
-  export(name: string): Promise<Response>;
+  export(name: string, fromHistory: boolean): Promise<Response>;
   /**
    * Create an environment from a packages list file
    *


### PR DESCRIPTION
https://github.com/conda/conda/pull/9093 introduced a new flag `--from-history` for conda > 4.7.12 that export only explicitly requested user package changes.

This PR add a new query argument *history* to *GET environments* to export using that option.

Query should be:

environments/*env-name*?download=1&history=1