### PR TITLE
Convert query args to int

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ jupyter labextension install .
 
 ## Changelog
 
+### 3.3.1
+
+- Bugs
+  - Fix export always from history (settings ignored)
+
 ### 3.3.0
 
 - Features

--- a/jupyter_conda/_version.py
+++ b/jupyter_conda/_version.py
@@ -1,2 +1,2 @@
-version_info = (3, 3, 0)
+version_info = (3, 3, 1)
 __version__ = ".".join(map(str, version_info))

--- a/jupyter_conda/handlers.py
+++ b/jupyter_conda/handlers.py
@@ -170,8 +170,8 @@ class EnvironmentsHandler(EnvBaseHandler):
         Raises:
             500 if an error occurs
         """
-        whitelist = self.get_query_argument("whitelist", 0)
-        list_envs = await self.env_manager.list_envs(int(whitelist) == 1)
+        whitelist = int(self.get_query_argument("whitelist", 0))
+        list_envs = await self.env_manager.list_envs(whitelist == 1)
         if "error" in list_envs:
             self.set_status(500)
         self.finish(tornado.escape.json_encode(list_envs))
@@ -236,8 +236,8 @@ class EnvironmentHandler(EnvBaseHandler):
             history: 0 (default) or 1
         """
         status = self.get_query_argument("status", "installed")
-        download = self.get_query_argument("download", 0)
-        history = self.get_query_argument("history", 0)
+        download = int(self.get_query_argument("download", 0))
+        history = int(self.get_query_argument("history", 0))
 
         if download:
             # export requirements file
@@ -333,7 +333,7 @@ class PackagesEnvironmentHandler(EnvBaseHandler):
         """
         body = self.get_json_body()
         packages = body["packages"]
-        develop = self.get_query_argument("develop", 0)
+        develop = int(self.get_query_argument("develop", 0))
 
         if develop:
             idx = self._stack.put(self.env_manager.develop_packages, env, packages)

--- a/jupyter_conda/tests/test_api.py
+++ b/jupyter_conda/tests/test_api.py
@@ -555,7 +555,7 @@ class TestEnvironmentHandler(JupyterCondaAPITest):
     def test_env_export(self):
         n = generate_name()
         self.wait_for_task(self.mk_env, n)
-        r = self.conda_api.get(["environments", n], params={"download": 1})
+        r = self.conda_api.get(["environments", n], params={"download": 1, "history": 0})
         self.assertEqual(r.status_code, 200)
 
         content = r.text


### PR DESCRIPTION
BUG Exporting environment is always using the history - settings is ignored.