### PR TITLE
Get packages list as early as possible

### DIFF
--- a/labextension/package.json
+++ b/labextension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab_conda",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Manage your conda environments from JupyterLab",
   "keywords": [
     "jupyter",

--- a/labextension/src/components/CondaPkgPanel.tsx
+++ b/labextension/src/components/CondaPkgPanel.tsx
@@ -435,12 +435,12 @@ export class CondaPkgPanel extends React.Component<
   async handleRefreshPackages(): Promise<void> {
     try {
       await this._model.refreshAvailablePackages();
-      this._updatePackages();
     } catch (error) {
       if (error.message !== "cancelled") {
         console.error("Error when refreshing the available packages.", error);
       }
     }
+    this._updatePackages();
   }
 
   componentDidUpdate(prevProps: IPkgPanelProps): void {

--- a/labextension/src/tokens.ts
+++ b/labextension/src/tokens.ts
@@ -149,8 +149,10 @@ export namespace Conda {
     ): Promise<Array<Conda.IPackage>>;
     /**
      * Refresh available package list
+     *
+     * @param cancellable Whether allowing this request to be cancelled or not?
      */
-    refreshAvailablePackages(): Promise<void>;
+    refreshAvailablePackages(cancellable?: boolean): Promise<void>;
     /**
      * Does the packages have description?
      */


### PR DESCRIPTION
Load available packages list as early as possible - as it takes a couple of minutes to build.

After a minute, start informing the user about that background task - if the list is cached no information will be displayed.